### PR TITLE
fix: remove duplicated labels on rbac components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,8 @@ helm: manifests kustomize helmify helm-docs
 	sed -i.bak 's|{{ include "cloudflare-zero-trust-operator.fullname" . }}-controller-manager|{{ include "cloudflare-zero-trust-operator.serviceAccountName" . }}|g' helm/cloudflare-zero-trust-operator/templates/*-rbac.yaml && rm helm/cloudflare-zero-trust-operator/templates/*-rbac.yaml.bak
 	rm -rf cloudflare-zero-trust-operator
 	$(HELM_DOCS)
-	# Remove lines starting with the specified strings from RBAC files
-	for file in helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-*-rbac.yaml; do \
+	# Remove app.kubernetes.io labels that conflict with FluxCD
+	for file in helm/cloudflare-zero-trust-operator/templates/*.yaml; do \
 		sed -i.bak '/^\( *\)app.kubernetes.io\/managed-by:/d; /^\( *\)app.kubernetes.io\/name:/d; /^\( *\)app.kubernetes.io\/instance:/d' "$$file"; \
 		rm -f "$$file.bak"; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,11 @@ helm: manifests kustomize helmify helm-docs
 	sed -i.bak 's|{{ include "cloudflare-zero-trust-operator.fullname" . }}-controller-manager|{{ include "cloudflare-zero-trust-operator.serviceAccountName" . }}|g' helm/cloudflare-zero-trust-operator/templates/*-rbac.yaml && rm helm/cloudflare-zero-trust-operator/templates/*-rbac.yaml.bak
 	rm -rf cloudflare-zero-trust-operator
 	$(HELM_DOCS)
+	# Remove lines starting with the specified strings from RBAC files
+	for file in helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-*-rbac.yaml; do \
+		sed -i.bak '/^\( *\)app.kubernetes.io\/managed-by:/d; /^\( *\)app.kubernetes.io\/name:/d; /^\( *\)app.kubernetes.io\/instance:/d' "$$file"; \
+		rm -f "$$file.bak"; \
+	done
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-leader-election-rbac.yaml
+++ b/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-leader-election-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: role
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 rules:
@@ -50,9 +47,6 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rolebinding
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 roleRef:

--- a/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-manager-rbac.yaml
+++ b/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-manager-rbac.yaml
@@ -103,9 +103,6 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 roleRef:

--- a/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-metrics-reader-rbac.yaml
+++ b/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-metrics-reader-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 rules:

--- a/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-proxy-rbac.yaml
+++ b/helm/cloudflare-zero-trust-operator/templates/f-zero-trust-operator-proxy-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: proxy-role
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 rules:
@@ -31,9 +28,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: bojanzelic-cloudflare-zero-trust-operator
-    app.kubernetes.io/instance: proxy-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: bojanzelic-cloudflare-zero-trust-operator
   {{- include "cloudflare-zero-trust-operator.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
I was trying to use your operator with FluxCD and noticed that the RBAC components already have the following labels defined in `cloudflare-zero-trust-operator.labels`. 


- `app.kubernetes.io/instance`
- `app.kubernetes.io/managed-by`
- `app.kubernetes.io/name`

Therefore when the chart is rendered, there's duplication of labels. 
This makes it impossible to use with FluxCD due to [#283](https://github.com/fluxcd/helm-controller/issues/283).

Thank you in advance!