### PR TITLE
Feat/no autoredirectto identity default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ metadata:
 spec:
   name: my application
   domain: domain.example.com
+  autoRedirectToIdentity: true
   policies: 
     - name: Allow testemail1
       decision: allow

--- a/api/v1alpha1/cloudflareaccessapplication_types.go
+++ b/api/v1alpha1/cloudflareaccessapplication_types.go
@@ -53,7 +53,7 @@ type CloudflareAccessApplicationSpec struct {
 	// When set to true, users skip the identity provider selection step during login.
 	// You must specify only one identity provider in allowed_idps.
 	// +optional
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	AutoRedirectToIdentity *bool `json:"autoRedirectToIdentity,omitempty"`
 
 	// Policies is the ordered set of policies that should be applied to the application

--- a/config/crd/bases/cloudflare.zelic.io_cloudflareaccessapplications.yaml
+++ b/config/crd/bases/cloudflare.zelic.io_cloudflareaccessapplications.yaml
@@ -49,7 +49,7 @@ spec:
                 description: Displays the application in the App Launcher.
                 type: boolean
               autoRedirectToIdentity:
-                default: true
+                default: false
                 description: When set to true, users skip the identity provider selection
                   step during login. You must specify only one identity provider in
                   allowed_idps.

--- a/docs/Advanced_Usage.md
+++ b/docs/Advanced_Usage.md
@@ -31,6 +31,7 @@ metadata:
 spec:
   name: my application
   domain: domain.example.com
+  autoRedirectToIdentity: true
   policies: 
     - name: Allow testemail1
       decision: allow


### PR DESCRIPTION
Breaking change. Instead of making an assumption that the user only has 1 IDP configured in cloudflare and the reconcilliation would error, we set this property to "false" and allow the user to set it to true when creating the AccessApp