### PR TITLE
fix metric scraping for helm chart

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
+      port: 8443
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:

--- a/helm/cloudflare-zero-trust-operator/templates/deployment.yaml
+++ b/helm/cloudflare-zero-trust-operator/templates/deployment.yaml
@@ -36,36 +36,15 @@ spec:
                     values:
                       - amd64
                       - arm64
-                      - ppc64le
-                      - s390x
                   - key: kubernetes.io/os
                     operator: In
                     values:
                       - linux
       containers:
         - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-          name: kube-rbac-proxy
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
-          resources:
-            {{- toYaml .Values.proxy.resources | nindent 12 }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-        - args:
-            - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
-            - --leader-elect
+          - --metrics-bind-address=:8443
+          - --leader-elect
+          - --health-probe-bind-address=:8081
           command:
             - /manager
           env:


### PR DESCRIPTION
fixes https://github.com/BojanZelic/cloudflare-zero-trust-operator/issues/145

the exising helm chart values still have kube-rbac-proxy but it should be removed as its unnecessary 